### PR TITLE
bug fix:resolve issue with content negotiation accept header in the ResponseFormatter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,3 +96,10 @@ chore(deps): update dependencies and fix environment config
 ## 2.0.4  - 2025-03-03
 
 - Added support for Laravel 12s
+
+## 2.0.5  - 2025-04-30
+bug fix: resolve issue with content negotiation accept header in the ResponseFormatter
+    - Fixed the issue where the accept header was not being parsed correctly if null
+    - Set the default content type to application/json
+    - Updated the CHANGELOG.md to reflect the changes made in this commit
+    - Update composer dependencies

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Latest Version on Packagist](https://img.shields.io/packagist/v/creativecrafts/laravel-api-response.svg?style=flat-square)](https://packagist.org/packages/creativecraft/laravel-api-response)
 [![GitHub Tests Action Status](https://img.shields.io/github/actions/workflow/status/creativecrafts/laravel-api-response/run-tests.yml?branch=main&label=tests&style=flat-square)](https://github.com/creativecraft/laravel-api-response/actions?query=workflow%3Arun-tests+branch%3Amain)
 [![GitHub Code Style Action Status](https://img.shields.io/github/actions/workflow/status/creativecrafts/laravel-api-response/fix-php-code-style-issues.yml?branch=main&label=code%20style&style=flat-square)](https://github.com/creativecraft/laravel-api-response/actions?query=workflow%3A"Fix+PHP+code+style+issues"+branch%3Amain)
-[![Total Downloads](https://img.shields.io/packagist/dt/creativecraft/laravel-api-response.svg?style=flat-square)](https://packagist.org/packages/creativecrafts/laravel-api-response)
+[![Total Downloads](https://img.shields.io/packagist/dt/creativecrafts/laravel-api-response.svg?style=flat-square)](https://packagist.org/packages/creativecrafts/laravel-api-response)
 
 Laravel API Response is a powerful and flexible package that provides a standardized way to structure API responses in Laravel applications. It offers a range of features to enhance your API development experience, including consistent response formatting, conditional responses, pagination support, rate limiting, and more.
 

--- a/src/Helpers/ResponseFormatter.php
+++ b/src/Helpers/ResponseFormatter.php
@@ -194,7 +194,7 @@ final readonly class ResponseFormatter implements ResponseFormatterContract
         );
 
         /** @var string $acceptHeader */
-        $acceptHeader = request()->header('Accept');
+        $acceptHeader = request()->header(key: 'Accept', default: 'application/json');
         $responseFormat = (new ContentNegotiation())->type($acceptHeader);
 
         $response = $this->createResponse($formattedResponse, $responseFormat);


### PR DESCRIPTION
bug fix: resolve issue with content negotiation accept header in the ResponseFormatter
    - Fixed the issue where the accept header was not being parsed correctly if null
    - Set the default content type to application/json
    - Updated the CHANGELOG.md to reflect the changes made in this commit
    - Update composer dependencies